### PR TITLE
docs: add no cache headers to index.html

### DIFF
--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -17,6 +17,14 @@ export default defineNuxtConfig({
 
   app: {
     baseURL: "/wordclock/",
+    head: {
+      // Meta tags to prevent github from caching the page for ages
+      meta: [
+        { "http-equiv": "cache-control", content: "no-cache" },
+        { "http-equiv": "expires", content: "0" },
+        { "http-equiv": "pragma", content: "no-cache" },
+      ],
+    },
   },
 
   scripts: {


### PR DESCRIPTION
This is to try to get GitHub to not cache the firmware binary for a long time leading to users installing an outdated version